### PR TITLE
Forge Support

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/util/GameProfile.java
+++ b/api/src/main/java/com/velocitypowered/api/util/GameProfile.java
@@ -57,7 +57,7 @@ public final class GameProfile {
                 '}';
     }
 
-    public final class Property {
+    public final static class Property {
         private final String name;
         private final String value;
         private final String signature;

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -47,6 +47,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     private MinecraftConnectionAssociation association;
     private boolean isLegacyForge;
     private final VelocityServer server;
+    private boolean canSendLegacyFMLResetPacket = false;
 
     public MinecraftConnection(Channel channel, VelocityServer server) {
         this.channel = channel;
@@ -230,5 +231,13 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
     public void setLegacyForge(boolean isForge) {
         this.isLegacyForge = isForge;
+    }
+
+    public boolean canSendLegacyFMLResetPacket() {
+        return canSendLegacyFMLResetPacket;
+    }
+
+    public void setCanSendLegacyFMLResetPacket(boolean canSendLegacyFMLResetPacket) {
+        this.canSendLegacyFMLResetPacket = isLegacyForge && canSendLegacyFMLResetPacket;
     }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -45,6 +45,7 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
     private MinecraftSessionHandler sessionHandler;
     private int protocolVersion;
     private MinecraftConnectionAssociation association;
+    private boolean isLegacyForge;
     private final VelocityServer server;
 
     public MinecraftConnection(Channel channel, VelocityServer server) {
@@ -221,5 +222,13 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
 
     public void setAssociation(MinecraftConnectionAssociation association) {
         this.association = association;
+    }
+
+    public boolean isLegacyForge() {
+        return isLegacyForge;
+    }
+
+    public void setLegacyForge(boolean isForge) {
+        this.isLegacyForge = isForge;
     }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/VelocityConstants.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/VelocityConstants.java
@@ -6,4 +6,8 @@ public class VelocityConstants {
     }
 
     public static final String VELOCITY_IP_FORWARDING_CHANNEL = "velocity:player_info";
+
+    public static final String FORGE_LEGACY_HANDSHAKE_CHANNEL = "FML|HS";
+
+    public static final byte[] FORGE_LEGACY_HANDSHAKE_RESET_DATA = new byte[] { -2, 0 };
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -88,7 +88,7 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
             if (status == MessageHandler.ForwardStatus.FORWARD) {
                 connection.getPlayer().getConnection().write(pm);
             }
-        } else {
+        } else if (connection.hasCompletedJoin()) {
             // Just forward the packet on. We don't have anything to handle at this time.
             connection.getPlayer().getConnection().write(packet);
         }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -102,7 +102,10 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
             connection.getMinecraftConnection().close();
             return;
         }
-        connection.getPlayer().getConnection().write(buf.retain());
+
+        if (connection.hasCompletedJoin()) {
+            connection.getPlayer().getConnection().write(buf.retain());
+        }
     }
 
     @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
@@ -84,6 +84,10 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
                 connection.getPlayer().getConnection().setSessionHandler(new ClientPlaySessionHandler(server, connection.getPlayer()));
             } else {
                 // The previous server connection should become obsolete.
+                // Before we remove it, if the server we are departing is modded, we must always reset the client state.
+                if (existingConnection.isModded()) {
+                    connection.getPlayer().sendLegacyForgeHandshakeResetPacket();
+                }
                 existingConnection.disconnect();
             }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -109,6 +109,8 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
         handshake.setProtocolVersion(proxyPlayer.getConnection().getProtocolVersion());
         if (forwardingMode == PlayerInfoForwarding.LEGACY) {
             handshake.setServerAddress(createBungeeForwardingAddress());
+        } else if (proxyPlayer.getConnection().isLegacyForge()) {
+            handshake.setServerAddress(handshake.getServerAddress() + "\0FML\0");
         } else {
             handshake.setServerAddress(serverInfo.getAddress().getHostString());
         }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -43,6 +43,8 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
     private final ConnectedPlayer proxyPlayer;
     private final VelocityServer server;
     private MinecraftConnection minecraftConnection;
+    private boolean isModded = false;
+    private boolean hasCompletedJoin = false;
 
     public VelocityServerConnection(ServerInfo target, ConnectedPlayer proxyPlayer, VelocityServer server) {
         this.serverInfo = target;
@@ -153,5 +155,21 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
         message.setChannel(identifier.getId());
         message.setData(data);
         minecraftConnection.write(message);
+    }
+
+    public boolean isModded() {
+        return isModded;
+    }
+
+    public void setModded(boolean modded) {
+        isModded = modded;
+    }
+
+    public boolean hasCompletedJoin() {
+        return hasCompletedJoin;
+    }
+
+    public void setHasCompletedJoin(boolean hasCompletedJoin) {
+        this.hasCompletedJoin = hasCompletedJoin;
     }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -122,12 +122,16 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         }
 
         // If we don't want to handle this packet, just forward it on.
-        player.getConnectedServer().getMinecraftConnection().write(packet);
+        if (player.getConnectedServer().hasCompletedJoin()) {
+            player.getConnectedServer().getMinecraftConnection().write(packet);
+        }
     }
 
     @Override
     public void handleUnknown(ByteBuf buf) {
-        player.getConnectedServer().getMinecraftConnection().write(buf.retain());
+        if (player.getConnectedServer().hasCompletedJoin()) {
+            player.getConnectedServer().getMinecraftConnection().write(buf.retain());
+        }
     }
 
     @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -235,6 +235,12 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
             return;
         }
 
+        if (player.getConnectedServer().isModded() && !player.getConnectedServer().hasCompletedJoin()) {
+            // Ensure that the messages are forwarded
+            player.getConnectedServer().getMinecraftConnection().write(packet);
+            return;
+        }
+
         MessageHandler.ForwardStatus status = server.getChannelRegistrar().handlePluginMessage(player,
                 ChannelSide.FROM_CLIENT, packet);
         if (status == MessageHandler.ForwardStatus.FORWARD) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -61,6 +61,8 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
             }
             player.setPing(System.currentTimeMillis() - lastPingSent);
             resetPingData();
+            player.getConnectedServer().getMinecraftConnection().write(packet);
+            return;
         }
 
         if (packet instanceof ClientSettings) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -197,6 +197,8 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
         // Flush everything
         player.getConnection().flush();
         player.getConnectedServer().getMinecraftConnection().flush();
+        player.getConnectedServer().setHasCompletedJoin(true);
+        player.getConnection().setCanSendLegacyFMLResetPacket(true);
     }
 
     public List<UUID> getServerBossBars() {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -15,6 +15,7 @@ import com.velocitypowered.api.util.MessagePosition;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnectionAssociation;
+import com.velocitypowered.proxy.connection.VelocityConstants;
 import com.velocitypowered.proxy.connection.util.ConnectionMessages;
 import com.velocitypowered.proxy.connection.util.ConnectionRequestResults;
 import com.velocitypowered.api.util.GameProfile;
@@ -292,6 +293,13 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
             this.tryIndex = 0;
         }
         this.connectedServer = serverConnection;
+    }
+
+    public void sendLegacyForgeHandshakeResetPacket() {
+        PluginMessage resetPacket = new PluginMessage();
+        resetPacket.setChannel(VelocityConstants.FORGE_LEGACY_HANDSHAKE_CHANNEL);
+        resetPacket.setData(VelocityConstants.FORGE_LEGACY_HANDSHAKE_RESET_DATA);
+        connection.write(resetPacket);
     }
 
     public void close(TextComponent reason) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -296,10 +296,13 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     }
 
     public void sendLegacyForgeHandshakeResetPacket() {
-        PluginMessage resetPacket = new PluginMessage();
-        resetPacket.setChannel(VelocityConstants.FORGE_LEGACY_HANDSHAKE_CHANNEL);
-        resetPacket.setData(VelocityConstants.FORGE_LEGACY_HANDSHAKE_RESET_DATA);
-        connection.write(resetPacket);
+        if (connection.canSendLegacyFMLResetPacket()) {
+            PluginMessage resetPacket = new PluginMessage();
+            resetPacket.setChannel(VelocityConstants.FORGE_LEGACY_HANDSHAKE_CHANNEL);
+            resetPacket.setData(VelocityConstants.FORGE_LEGACY_HANDSHAKE_RESET_DATA);
+            connection.write(resetPacket);
+            connection.setCanSendLegacyFMLResetPacket(false);
+        }
     }
 
     public void close(TextComponent reason) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -70,9 +70,12 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
                     return;
                 }
 
-                // Make sure legacy forwarding is not in use on this connection. Make sure that we do _not_ reject Forge,
-                // although Velocity does not yet support Forge.
-                if (handshake.getServerAddress().contains("\0") && !handshake.getServerAddress().endsWith("\0FML\0")) {
+                // Determine if we're using Forge (1.8 to 1.12, may not be the case in 1.13) and store that in the connection
+                boolean isForge = handshake.getServerAddress().endsWith("\0FML\0");
+                connection.setLegacyForge(isForge);
+
+                // Make sure legacy forwarding is not in use on this connection. Make sure that we do _not_ reject Forge
+                if (handshake.getServerAddress().contains("\0") && !isForge) {
                     connection.closeWith(Disconnect.create(TextComponent.of("Running Velocity behind Velocity is unsupported.")));
                     return;
                 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
@@ -8,6 +8,7 @@ import com.velocitypowered.api.event.permission.PermissionsSetupEvent;
 import com.velocitypowered.api.event.player.GameProfileRequestEvent;
 import com.velocitypowered.api.proxy.InboundConnection;
 import com.velocitypowered.api.proxy.server.ServerInfo;
+import com.velocitypowered.proxy.config.PlayerInfoForwarding;
 import com.velocitypowered.proxy.connection.VelocityConstants;
 import com.velocitypowered.api.util.GameProfile;
 import com.velocitypowered.proxy.protocol.MinecraftPacket;
@@ -31,7 +32,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -176,6 +179,12 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
     }
 
     private void initializePlayer(GameProfile profile, boolean onlineMode) {
+        if (inbound.isLegacyForge() && server.getConfiguration().getPlayerInfoForwardingMode() == PlayerInfoForwarding.LEGACY) {
+            // We want to add the FML token to the properties
+            List<GameProfile.Property> properties = new ArrayList<>(profile.getProperties());
+            properties.add(new GameProfile.Property("forgeClient", "true", ""));
+            profile = new GameProfile(profile.getId(), profile.getName(), properties);
+        }
         GameProfileRequestEvent profileRequestEvent = new GameProfileRequestEvent(apiInbound, profile, onlineMode);
 
         server.getEventManager().fire(profileRequestEvent).thenCompose(profileEvent -> {


### PR DESCRIPTION
Add support for Forge 1.8-1.12

For the most part, we don't need to intercept `FML|HS` packets, except to detemine when to tell the client to reset the handshake ready for a new one. That's what most of this code actually does. It also implements my `GameProfile` method of indicating to SpongeForge that the incoming client is a Forge client.

Happy for comments/reviews etc. It is a relatively unintrusive change and does not affect Vanilla play.