### PR TITLE
Don't fire a FML reset packet on first login, set it as required for the second join after the first completes

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/LoginSessionHandler.java
@@ -82,12 +82,6 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
             if (existingConnection == null) {
                 // Strap on the play session handler
                 connection.getPlayer().getConnection().setSessionHandler(new ClientPlaySessionHandler(server, connection.getPlayer()));
-
-                // This is for legacy Forge servers - during first connection the FML handshake will transition to complete regardless
-                // Thus, we need to ensure that a reset packet is ALWAYS sent on first switch.
-                //
-                // The call will handle if the player is not a Forge player appropriately.
-                connection.getPlayer().getConnection().setCanSendLegacyFMLResetPacket(true);
             } else {
                 // The previous server connection should become obsolete.
                 // Before we remove it, if the server we are departing is modded, we must always reset the client state.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -164,9 +164,19 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
     public void handleBackendJoinGame(JoinGame joinGame) {
         resetPingData(); // reset ping data;
         if (!spawned) {
-            // nothing special to do here
+            // Nothing special to do with regards to spawning the player
             spawned = true;
             player.getConnection().delayedWrite(joinGame);
+
+            // We have something special to do for legacy Forge servers - during first connection the FML handshake
+            // will transition to complete regardless. Thus, we need to ensure that a reset packet is ALWAYS sent on
+            // first switch.
+            //
+            // As we know that calling this branch only happens on first join, we set that if we are a Forge
+            // client that we must reset on the next switch.
+            //
+            // The call will handle if the player is not a Forge player appropriately.
+            player.getConnection().setCanSendLegacyFMLResetPacket(true);
         } else {
             // Ah, this is the meat and potatoes of the whole venture!
             //


### PR DESCRIPTION
Simply moved setting the "can send reset packet" status to the client play handler, as that has a branch that is only executed during the first join (after the FML handshake will have completed first time)

Untested, will test later if someone doesn't get there before me (but it should work!)

Fixes #69 (again)