### PR TITLE
Add CONNECT_TIMEOUT_MILLIS to fix timeout errors.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -56,6 +56,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
         CompletableFuture<ConnectionRequestBuilder.Result> result = new CompletableFuture<>();
         server.initializeGenericBootstrap()
                 .option(ChannelOption.TCP_NODELAY, true)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, SERVER_READ_TIMEOUT_SECONDS * 1000)
                 .handler(new ChannelInitializer<Channel>() {
                     @Override
                     protected void initChannel(Channel ch) throws Exception {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -33,6 +33,7 @@ import static com.velocitypowered.proxy.network.Connections.HANDLER;
 import static com.velocitypowered.proxy.network.Connections.MINECRAFT_DECODER;
 import static com.velocitypowered.proxy.network.Connections.MINECRAFT_ENCODER;
 import static com.velocitypowered.proxy.network.Connections.READ_TIMEOUT;
+import static com.velocitypowered.proxy.network.Connections.CONNECTION_TIMEOUT_SECONDS;
 import static com.velocitypowered.proxy.network.Connections.SERVER_READ_TIMEOUT_SECONDS;
 
 public class VelocityServerConnection implements MinecraftConnectionAssociation, ServerConnection {
@@ -56,7 +57,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
         CompletableFuture<ConnectionRequestBuilder.Result> result = new CompletableFuture<>();
         server.initializeGenericBootstrap()
                 .option(ChannelOption.TCP_NODELAY, true)
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, SERVER_READ_TIMEOUT_SECONDS * 1000)
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECTION_TIMEOUT_SECONDS * 1000)
                 .handler(new ChannelInitializer<Channel>() {
                     @Override
                     protected void initChannel(Channel ch) throws Exception {

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
@@ -89,7 +89,7 @@ public final class ConnectionManager {
                         ch.pipeline().addLast(Connections.HANDLER, connection);
                     }
                 })
-                .childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, CLIENT_READ_TIMEOUT_SECONDS * 1000)
+                .childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECTION_TIMEOUT_SECONDS * 1000)
                 .childOption(ChannelOption.TCP_NODELAY, true)
                 .childOption(ChannelOption.IP_TOS, 0x18)
                 .localAddress(address);

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ConnectionManager.java
@@ -89,6 +89,7 @@ public final class ConnectionManager {
                         ch.pipeline().addLast(Connections.HANDLER, connection);
                     }
                 })
+                .childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, CLIENT_READ_TIMEOUT_SECONDS * 1000)
                 .childOption(ChannelOption.TCP_NODELAY, true)
                 .childOption(ChannelOption.IP_TOS, 0x18)
                 .localAddress(address);

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/Connections.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/Connections.java
@@ -16,4 +16,5 @@ public interface Connections {
 
     int CLIENT_READ_TIMEOUT_SECONDS = 30; // client -> proxy
     int SERVER_READ_TIMEOUT_SECONDS = 30; // proxy -> server
+    int CONNECTION_TIMEOUT_SECONDS = 5;
 }


### PR DESCRIPTION
For some reason having a read timeout handler is not enough. Without this option players will randomly timeout from backend servers.