### PR TITLE
Modinfo: Add getType and getModList methods.

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/server/ServerPing.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/server/ServerPing.java
@@ -317,7 +317,7 @@ public class ServerPing {
             return type;
         }
 
-        public List<Mod> getModList() {
+        public List<Mod> getMods() {
             return modList;
         }
     }

--- a/api/src/main/java/com/velocitypowered/api/proxy/server/ServerPing.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/server/ServerPing.java
@@ -312,6 +312,14 @@ public class ServerPing {
             this.type = Preconditions.checkNotNull(type, "type");
             this.modList = ImmutableList.copyOf(modList);
         }
+
+        public String getType() {
+            return type;
+        }
+
+        public List<Mod> getModList() {
+            return modList;
+        }
     }
 
     public static class Mod {


### PR DESCRIPTION
Once forced hosts are implemented this will allow caching of mod lists and the ability return them during proxy ping events.