### PR TITLE
Implement optional permission check method for commands

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/Command.java
+++ b/api/src/main/java/com/velocitypowered/api/command/Command.java
@@ -26,4 +26,19 @@ public interface Command {
     default List<String> suggest(@NonNull CommandSource source, @NonNull String[] currentArgs) {
         return ImmutableList.of();
     }
+
+    /**
+     * Tests to check if the {@code source} has permission to use this command
+     * with the provided {@code args}.
+     *
+     * <p>If this method returns false, the handling will be forwarded onto
+     * the players current server.</p>
+     *
+     * @param source the source of the command
+     * @param args the arguments for this command
+     * @return whether the source has permission
+     */
+    default boolean hasPermission(@NonNull CommandSource source, @NonNull String[] args) {
+        return true;
+    }
 }

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionFunction.java
@@ -29,5 +29,5 @@ public interface PermissionFunction {
      * @param permission the permission
      * @return the value the permission is set to
      */
-    @NonNull Tristate getPermissionSetting(@NonNull String permission);
+    @NonNull Tristate getPermissionValue(@NonNull String permission);
 }

--- a/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
+++ b/api/src/main/java/com/velocitypowered/api/permission/PermissionSubject.java
@@ -12,5 +12,15 @@ public interface PermissionSubject {
      * @param permission the permission to check for
      * @return whether or not the subject has the permission
      */
-    boolean hasPermission(@NonNull String permission);
+    default boolean hasPermission(@NonNull String permission) {
+        return getPermissionValue(permission).asBoolean();
+    }
+
+    /**
+     * Gets the subjects setting for a particular permission.
+     *
+     * @param permission the permission
+     * @return the value the permission is set to
+     */
+    @NonNull Tristate getPermissionValue(@NonNull String permission);
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -8,6 +8,7 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.event.EventManager;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.api.plugin.PluginManager;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
@@ -39,6 +40,7 @@ import net.kyori.text.serializer.ComponentSerializers;
 import net.kyori.text.serializer.GsonComponentSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
@@ -77,8 +79,8 @@ public class VelocityServer implements ProxyServer {
         }
 
         @Override
-        public boolean hasPermission(String permission) {
-            return true;
+        public @NonNull Tristate getPermissionValue(@NonNull String permission) {
+            return Tristate.TRUE;
         }
     };
     private Ratelimiter ipAttemptLimiter;

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/ServerCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/ServerCommand.java
@@ -3,6 +3,7 @@ package com.velocitypowered.proxy.command;
 import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.ServerConnection;
@@ -12,6 +13,7 @@ import net.kyori.text.TextComponent;
 import net.kyori.text.event.ClickEvent;
 import net.kyori.text.event.HoverEvent;
 import net.kyori.text.format.TextColor;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.List;
 import java.util.Optional;
@@ -87,5 +89,10 @@ public class ServerCommand implements Command {
         } else {
             return ImmutableList.of();
         }
+    }
+
+    @Override
+    public boolean hasPermission(@NonNull CommandSource source, @NonNull String[] args) {
+        return source.getPermissionValue("velocity.command.server") != Tristate.FALSE;
     }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/ShutdownCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/ShutdownCommand.java
@@ -5,6 +5,7 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.proxy.VelocityServer;
 import net.kyori.text.TextComponent;
 import net.kyori.text.format.TextColor;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class ShutdownCommand implements Command {
     private final VelocityServer server;
@@ -20,5 +21,10 @@ public class ShutdownCommand implements Command {
             return;
         }
         server.shutdown();
+    }
+
+    @Override
+    public boolean hasPermission(@NonNull CommandSource source, @NonNull String[] args) {
+        return source == server.getConsoleCommandSource();
     }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommand.java
@@ -2,10 +2,12 @@ package com.velocitypowered.proxy.command;
 
 import com.velocitypowered.api.command.Command;
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.proxy.VelocityServer;
 import net.kyori.text.TextComponent;
 import net.kyori.text.event.ClickEvent;
 import net.kyori.text.format.TextColor;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 public class VelocityCommand implements Command {
     @Override
@@ -36,5 +38,10 @@ public class VelocityCommand implements Command {
         source.sendMessage(thisIsVelocity);
         source.sendMessage(velocityInfo);
         source.sendMessage(velocityWebsite);
+    }
+
+    @Override
+    public boolean hasPermission(@NonNull CommandSource source, @NonNull String[] args) {
+        return source.getPermissionValue("velocity.command.info") != Tristate.FALSE;
     }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -7,6 +7,7 @@ import com.velocitypowered.api.event.player.PlayerSettingsChangedEvent;
 import com.velocitypowered.api.event.player.ServerPreConnectEvent;
 import com.velocitypowered.api.permission.PermissionFunction;
 import com.velocitypowered.api.permission.PermissionProvider;
+import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.api.proxy.ConnectionRequestBuilder;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ServerConnection;
@@ -335,8 +336,8 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     }
 
     @Override
-    public boolean hasPermission(String permission) {
-        return permissionFunction.getPermissionSetting(permission).asBoolean();
+    public @NonNull Tristate getPermissionValue(@NonNull String permission) {
+        return permissionFunction.getPermissionValue(permission);
     }
 
     @Override


### PR DESCRIPTION
This allows plugins to customize which players can use their commands. For players without permission, the command is effectively invisible, and the handling is passed through to the backend server.


Will conflict with #98 (depending on what gets merged first, if any)