### PR TITLE
Fix configuration saving

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -147,16 +147,15 @@ public class VelocityServer implements ProxyServer {
       Path configPath = Paths.get("velocity.toml");
       configuration = VelocityConfiguration.read(configPath);
 
+      AnnotatedConfig
+              .saveConfig(configuration.dumpConfig(), configPath); // Resave config to add new values
+
       if (!configuration.validate()) {
         logger.error(
             "Your configuration is invalid. Velocity will refuse to start up until the errors are resolved.");
         LogManager.shutdown();
         System.exit(1);
       }
-
-      AnnotatedConfig
-          .saveConfig(configuration.dumpConfig(), configPath); //Resave config to add new values
-
     } catch (Exception e) {
       logger.error("Unable to read/load/save your velocity.toml. The server will shut down.", e);
       LogManager.shutdown();

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/AnnotatedConfig.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/AnnotatedConfig.java
@@ -125,7 +125,7 @@ public abstract class AnnotatedConfig {
 
         // Get a key name for config. Use field name if @ConfigKey annotation is not present.
         ConfigKey key = field.getAnnotation(ConfigKey.class);
-        final String name = safeKey(key == null ? field.getName() : key.value());
+        final String name = escapeKeyIfNeeded(key == null ? field.getName() : key.value());
 
         Object value = field.get(dumpable);
 
@@ -142,7 +142,7 @@ public abstract class AnnotatedConfig {
           Map<String, ?> map = (Map<String, ?>) value;
           for (Entry<String, ?> entry : map.entrySet()) {
             lines.add(
-                safeKey(entry.getKey()) + " = " + serialize(entry.getValue())); // Save map data
+                escapeKeyIfNeeded(entry.getKey()) + " = " + serialize(entry.getValue())); // Save map data
           }
           lines.add(""); // Add empty line
           continue;
@@ -203,10 +203,18 @@ public abstract class AnnotatedConfig {
     return value != null ? value.toString() : "null";
   }
 
-  private static String safeKey(String key) {
+  protected static String escapeKeyIfNeeded(String key) {
     if (key.contains(".") && !(key.indexOf('"') == 0 && key.lastIndexOf('"') == (key.length()
         - 1))) {
       return '"' + key + '"';
+    }
+    return key;
+  }
+
+  protected static String unesacpeKeyIfNeeded(String key) {
+    int lastIndex;
+    if (key.indexOf('"') == 0 && (lastIndex = key.lastIndexOf('"')) == (key.length() - 1)) {
+      return key.substring(1, lastIndex);
     }
     return key;
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -487,9 +487,9 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
         for (Map.Entry<String, Object> entry : toml.entrySet()) {
           if (entry.getValue() instanceof String) {
             forcedHosts
-                .put(stripQuotes(entry.getKey()), ImmutableList.of((String) entry.getValue()));
+                .put(unesacpeKeyIfNeeded(entry.getKey()), ImmutableList.of((String) entry.getValue()));
           } else if (entry.getValue() instanceof List) {
-            forcedHosts.put(stripQuotes(entry.getKey()),
+            forcedHosts.put(unesacpeKeyIfNeeded(entry.getKey()),
                 ImmutableList.copyOf((List<String>) entry.getValue()));
           } else {
             throw new IllegalStateException(
@@ -510,14 +510,6 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
 
     private void setForcedHosts(Map<String, List<String>> forcedHosts) {
       this.forcedHosts = forcedHosts;
-    }
-
-    private static String stripQuotes(String key) {
-      int lastIndex;
-      if (key.indexOf('"') == 0 && (lastIndex = key.lastIndexOf('"')) == (key.length() - 1)) {
-        return key.substring(1, lastIndex);
-      }
-      return key;
     }
 
     @Override


### PR DESCRIPTION
Example: if user removes `[forced-hosts]` section from configuration and (obviously) has modified `[server]` section with server names which aren't in forced hosts default configuration, then configuration validation would fail on startup, but file wouldn't get re-saved with default values.

Also I moved and renamed key escaping/unescaping methods to AnnotatedConfig class.