### PR TITLE
Add option to get command label in Command#execute.

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/Command.java
+++ b/api/src/main/java/com/velocitypowered/api/command/Command.java
@@ -16,7 +16,16 @@ public interface Command {
    * @param source the source of this command
    * @param args the arguments for this command
    */
-  void execute(CommandSource source, String @NonNull [] args);
+  default void execute(CommandSource source, String @NonNull [] args) {}
+
+  /**
+   * Executes the command for the specified {@link CommandSource}.
+   *
+   * @param source the source of this command
+   * @param label the label for this command
+   * @param args the arguments for this command
+   */
+  default void execute(CommandSource source, @NonNull String label, String @NonNull [] args) {}
 
   /**
    * Provides tab complete suggestions for a command for a specified {@link CommandSource}.

--- a/api/src/main/java/com/velocitypowered/api/command/Command.java
+++ b/api/src/main/java/com/velocitypowered/api/command/Command.java
@@ -16,16 +16,17 @@ public interface Command {
    * @param source the source of this command
    * @param args the arguments for this command
    */
+  @Deprecated
   default void execute(CommandSource source, String @NonNull [] args) {}
 
   /**
    * Executes the command for the specified {@link CommandSource}.
    *
    * @param source the source of this command
-   * @param label the label for this command
+   * @param alias the alias for this command
    * @param args the arguments for this command
    */
-  default void execute(CommandSource source, @NonNull String label, String @NonNull [] args) {}
+  default void execute(CommandSource source, @NonNull String alias, String @NonNull [] args) {}
 
   /**
    * Provides tab complete suggestions for a command for a specified {@link CommandSource}.

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -58,6 +58,7 @@ public class VelocityCommandManager implements CommandManager {
       }
 
       command.execute(source, actualArgs);
+      command.execute(source, split[0], actualArgs);
       return true;
     } catch (Exception e) {
       throw new RuntimeException("Unable to invoke command " + cmdLine + " for " + source, e);


### PR DESCRIPTION
This adds another method to [Command](https://jd.velocitypowered.com/com/velocitypowered/api/command/Command.html) which supplies the label of the command being run. Additionally, both the new and old execute methods default to do nothing.