### PR TITLE
Send only one respawn packet on server switch

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -314,11 +314,8 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       // Most notably, by having the client accept the join game packet, we can work around the need
       // to perform entity ID rewrites, eliminating potential issues from rewriting packets and
       // improving compatibility with mods.
+      joinGame.setDimension(joinGame.getDimension() == 0 ? -1 : 0);
       player.getConnection().delayedWrite(joinGame);
-      int tempDim = joinGame.getDimension() == 0 ? -1 : 0;
-      player.getConnection().delayedWrite(
-          new Respawn(tempDim, joinGame.getDifficulty(), joinGame.getGamemode(),
-              joinGame.getLevelType()));
       player.getConnection().delayedWrite(
           new Respawn(joinGame.getDimension(), joinGame.getDifficulty(), joinGame.getGamemode(),
               joinGame.getLevelType()));

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -314,10 +314,11 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       // Most notably, by having the client accept the join game packet, we can work around the need
       // to perform entity ID rewrites, eliminating potential issues from rewriting packets and
       // improving compatibility with mods.
-      joinGame.setDimension(joinGame.getDimension() == 0 ? -1 : 0);
+      int realDim = joinGame.getDimension();
+      joinGame.setDimension(realDim == 0 ? -1 : 0);
       player.getConnection().delayedWrite(joinGame);
       player.getConnection().delayedWrite(
-          new Respawn(joinGame.getDimension(), joinGame.getDifficulty(), joinGame.getGamemode(),
+          new Respawn(realDim, joinGame.getDifficulty(), joinGame.getGamemode(),
               joinGame.getLevelType()));
     }
 


### PR DESCRIPTION
We can simply set dimension in JoinGame packet and send only one respawn packet. Useless, but why not?