### PR TITLE
register player connection only when switched to PLAY state

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -389,6 +389,17 @@ public class VelocityServer implements ProxyServer {
   }
 
   /**
+   * Checks if the {@code connection} can be registered with the proxy.
+   * @param connection the connection to check
+   * @return {@code true} if we can register the connection, {@code false} if not
+   */
+  public boolean canRegisterConnection(ConnectedPlayer connection) {
+    String lowerName = connection.getUsername().toLowerCase(Locale.US);
+    return !(connectionsByName.containsKey(lowerName)
+        || connectionsByUuid.containsKey(connection.getUniqueId()));
+  }
+  
+  /**
    * Attempts to register the {@code connection} with the proxy.
    * @param connection the connection to register
    * @return {@code true} if we registered the connection, {@code false} if not

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
@@ -231,18 +231,16 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
       return server.getEventManager()
           .fire(new PermissionsSetupEvent(player, ConnectedPlayer.DEFAULT_PERMISSIONS))
           .thenAcceptAsync(event -> {
-            // wait for permissions to load, then set the players permission function
-            player.setPermissionFunction(event.createFunction(player));
-            finishLogin(player);
+            if (!mcConnection.isClosed()) {
+              // wait for permissions to load, then set the players permission function
+              player.setPermissionFunction(event.createFunction(player));
+              finishLogin(player);
+            }
           }, mcConnection.eventLoop());
     });  
   }
 
   private void finishLogin(ConnectedPlayer player) {
-    if (mcConnection.isClosed()) {
-      // The player was disconnected
-      return;
-    }
     Optional<RegisteredServer> toTry = player.getNextServerToTry();
     if (!toTry.isPresent()) {
       player.disconnect(VelocityMessages.NO_AVAILABLE_SERVERS);

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
@@ -226,11 +226,6 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
         return CompletableFuture.completedFuture(null);
       }
 
-      // Fire DisconnectEvent if player will be disconnected/kicked during login and next events. 
-      // This will protect us from bad plugins, those will store Player object from events
-      // and remove it on disconnect
-      mcConnection.setSessionHandler(new InitialConnectSessionHandler(player));
-      
       logger.info("{} has connected", player);
 
       return server.getEventManager()
@@ -283,7 +278,8 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
               player.disconnect(VelocityMessages.ALREADY_CONNECTED);
               return;
             }
-
+            
+            mcConnection.setSessionHandler(new InitialConnectSessionHandler(player));
             server.getEventManager().fire(new PostLoginEvent(player))
                 .thenRun(() -> player.createConnectionRequest(toTry.get()).fireAndForget());
           }


### PR DESCRIPTION
This PR will fix a error caused when plugins try to send a title, message, header and footer, etc during login event. https://pastebin.com/Uwu9Q48f .