### PR TITLE
Fix DataFormatException with java decompression

### DIFF
--- a/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
+++ b/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
@@ -27,9 +27,13 @@ public class JavaVelocityCompressor implements VelocityCompressor {
   public void inflate(ByteBuf source, ByteBuf destination) throws DataFormatException {
     ensureNotDisposed();
 
-    byte[] inData = new byte[source.readableBytes()];
-    source.readBytes(inData);
-    inflater.setInput(inData);
+    if (source.hasArray()) {
+      inflater.setInput(source.array(), source.arrayOffset() + source.readerIndex(), source.readableBytes());
+    } else {
+      byte[] inData = new byte[source.readableBytes()];
+      source.readBytes(inData);
+      inflater.setInput(inData);
+    }
 
     while (!inflater.finished()) {
       int read = inflater.inflate(buf);
@@ -43,7 +47,7 @@ public class JavaVelocityCompressor implements VelocityCompressor {
     ensureNotDisposed();
 
     if (source.hasArray()) {
-      deflater.setInput(source.array(), source.arrayOffset(), source.readableBytes());
+      deflater.setInput(source.array(), source.arrayOffset() + source.readerIndex(), source.readableBytes());
     } else {
       byte[] inData = new byte[source.readableBytes()];
       source.readBytes(inData);

--- a/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
+++ b/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
@@ -28,7 +28,8 @@ public class JavaVelocityCompressor implements VelocityCompressor {
     ensureNotDisposed();
 
     if (source.hasArray()) {
-      inflater.setInput(source.array(), source.arrayOffset() + source.readerIndex(), source.readableBytes());
+      inflater.setInput(source.array(), source.arrayOffset() + source.readerIndex(),
+          source.readableBytes());
     } else {
       byte[] inData = new byte[source.readableBytes()];
       source.readBytes(inData);
@@ -47,7 +48,8 @@ public class JavaVelocityCompressor implements VelocityCompressor {
     ensureNotDisposed();
 
     if (source.hasArray()) {
-      deflater.setInput(source.array(), source.arrayOffset() + source.readerIndex(), source.readableBytes());
+      deflater.setInput(source.array(), source.arrayOffset() + source.readerIndex(),
+          source.readableBytes());
     } else {
       byte[] inData = new byte[source.readableBytes()];
       source.readBytes(inData);

--- a/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
+++ b/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
@@ -27,13 +27,9 @@ public class JavaVelocityCompressor implements VelocityCompressor {
   public void inflate(ByteBuf source, ByteBuf destination) throws DataFormatException {
     ensureNotDisposed();
 
-    if (source.hasArray()) {
-      inflater.setInput(source.array(), source.arrayOffset(), source.readableBytes());
-    } else {
-      byte[] inData = new byte[source.readableBytes()];
-      source.readBytes(inData);
-      inflater.setInput(inData);
-    }
+    byte[] inData = new byte[source.readableBytes()];
+    source.readBytes(inData);
+    inflater.setInput(inData);
 
     while (!inflater.finished()) {
       int read = inflater.inflate(buf);


### PR DESCRIPTION
In certain situations a client will fail to connect with an exception of `DataFormatException: unknown compression method` or `DataFormatException: incorrect header check`, this fixes that.

This was tested with a Direwolf20 modpack client against a SpongeVanilla server, the unknown compression method error happened with a localhost connection, the incorrect header check happened with the client connecting from outside the network.