### PR TITLE
Fix NPE's when a command isn't known by velocity.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -60,6 +60,9 @@ public class VelocityCommandManager implements CommandManager {
       args = cmdLine.substring(firstSpace).trim();
     }
     RawCommand command = commands.get(alias.toLowerCase(Locale.ENGLISH));
+    if (command == null) {
+      return false;
+    }
 
     try {
       if (!command.hasPermission(source, args)) {
@@ -140,6 +143,9 @@ public class VelocityCommandManager implements CommandManager {
       args = cmdLine.substring(firstSpace).trim();
     }
     RawCommand command = commands.get(alias.toLowerCase(Locale.ENGLISH));
+    if (command == null) {
+      return false;
+    }
 
     try {
       return command.hasPermission(source, args);


### PR DESCRIPTION
Only affects `dev/1.1.0` since https://github.com/VelocityPowered/Velocity/commit/7834acd67f84e83834a8888f81e570cc435d2e98