### PR TITLE
Show correct modinfo on server ping

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -79,6 +79,13 @@ public interface ProxyConfig {
   List<String> getAttemptConnectionOrder();
 
   /**
+   * Get the order of servers that mod info will be retrieved from
+   *
+   * @return mod info order list
+   */
+  List<String> getAttemptModInfoOrder();
+
+  /**
    * Get forced servers mapped to a given virtual host.
    *
    * @return list of server names

--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -79,7 +79,7 @@ public interface ProxyConfig {
   List<String> getAttemptConnectionOrder();
 
   /**
-   * Get the order of servers that mod info will be retrieved from
+   * Get the order of servers that mod info will be retrieved from.
    *
    * @return mod info order list
    */

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -322,6 +322,11 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
   }
 
   @Override
+  public List<String> getAttemptModInfoOrder() {
+    return servers.getAttemptModInfoOrder();
+  }
+
+  @Override
   public Map<String, List<String>> getForcedHosts() {
     return forcedHosts.getForcedHosts();
   }
@@ -459,6 +464,10 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
     @ConfigKey("try")
     private List<String> attemptConnectionOrder = Arrays.asList("lobby");
 
+    @Comment("In what order we should try servers when retrieving the mod list (only important when mods are installed)")
+    @ConfigKey("tryModInfo")
+    private List<String> attemptModInfoOrder = Arrays.asList("lobby");
+
     private Servers() {
     }
 
@@ -469,7 +478,7 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
           if (entry.getValue() instanceof String) {
             servers.put(entry.getKey(), (String) entry.getValue());
           } else {
-            if (!entry.getKey().equalsIgnoreCase("try")) {
+            if (!entry.getKey().equalsIgnoreCase("try") && !entry.getKey().equalsIgnoreCase("tryModInfo")) {
               throw new IllegalArgumentException(
                   "Server entry " + entry.getKey() + " is not a string!");
             }
@@ -477,6 +486,7 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
         }
         this.servers = ImmutableMap.copyOf(servers);
         this.attemptConnectionOrder = toml.getList("try", attemptConnectionOrder);
+        this.attemptModInfoOrder = toml.getList("tryModInfo", attemptConnectionOrder);
       }
     }
 
@@ -499,6 +509,14 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
 
     public void setAttemptConnectionOrder(List<String> attemptConnectionOrder) {
       this.attemptConnectionOrder = attemptConnectionOrder;
+    }
+
+    public List<String> getAttemptModInfoOrder() {
+      return attemptModInfoOrder;
+    }
+
+    public void setAttemptModInfoOrder(List<String> attemptModInfoOrder) {
+      this.attemptModInfoOrder = attemptModInfoOrder;
     }
 
     @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -464,7 +464,8 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
     @ConfigKey("try")
     private List<String> attemptConnectionOrder = Arrays.asList("lobby");
 
-    @Comment("In what order we should try servers when retrieving the mod list (only important when mods are installed)")
+    @Comment("In what order we should try servers when retrieving the mod list" +
+        "(only important when mods are installed)")
     @ConfigKey("tryModInfo")
     private List<String> attemptModInfoOrder = Arrays.asList("lobby");
 
@@ -478,7 +479,8 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
           if (entry.getValue() instanceof String) {
             servers.put(entry.getKey(), (String) entry.getValue());
           } else {
-            if (!entry.getKey().equalsIgnoreCase("try") && !entry.getKey().equalsIgnoreCase("tryModInfo")) {
+            if (!entry.getKey().equalsIgnoreCase("try")
+                && !entry.getKey().equalsIgnoreCase("tryModInfo")) {
               throw new IllegalArgumentException(
                   "Server entry " + entry.getKey() + " is not a string!");
             }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
@@ -52,12 +52,18 @@ public class StatusSessionHandler implements MinecraftSessionHandler {
   private ModInfo getModInfo(boolean isAnnounceForge) {
     for (String serverName : server.getConfiguration().getAttemptModInfoOrder()) {
       Optional<RegisteredServer> registeredServer = server.getServer(serverName);
-      if (!registeredServer.isPresent()) continue;
+      if (!registeredServer.isPresent()) {
+        continue;
+      }
       try {
         ServerPing serverPing = registeredServer.get().ping().get();
-        if (serverPing == null) continue;
+        if (serverPing == null) {
+          continue;
+        }
         Optional<ModInfo> modInfo = serverPing.getModinfo();
-        if (!modInfo.isPresent()) continue;
+        if (!modInfo.isPresent()) {
+          continue;
+        }
         return modInfo.get();
       } catch (InterruptedException | ExecutionException ignored) {
       }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
@@ -23,84 +23,84 @@ import java.util.concurrent.ExecutionException;
 
 public class StatusSessionHandler implements MinecraftSessionHandler {
 
-    private final VelocityServer server;
-    private final MinecraftConnection connection;
-    private final InboundConnection inboundWrapper;
+  private final VelocityServer server;
+  private final MinecraftConnection connection;
+  private final InboundConnection inboundWrapper;
 
-    StatusSessionHandler(VelocityServer server, MinecraftConnection connection,
-                         InboundConnection inboundWrapper) {
-        this.server = server;
-        this.connection = connection;
-        this.inboundWrapper = inboundWrapper;
-    }
+  StatusSessionHandler(VelocityServer server, MinecraftConnection connection,
+                       InboundConnection inboundWrapper) {
+    this.server = server;
+    this.connection = connection;
+    this.inboundWrapper = inboundWrapper;
+  }
 
-    private ServerPing createInitialPing() {
-        VelocityConfiguration configuration = server.getConfiguration();
-        ProtocolVersion shownVersion = ProtocolVersion.isSupported(connection.getProtocolVersion())
-                ? connection.getProtocolVersion() : ProtocolVersion.MAXIMUM_VERSION;
-        return new ServerPing(
-                new ServerPing.Version(shownVersion.getProtocol(),
-                        "Velocity " + ProtocolVersion.SUPPORTED_VERSION_STRING),
-                new ServerPing.Players(server.getPlayerCount(), configuration.getShowMaxPlayers(),
-                        ImmutableList.of()),
-                configuration.getMotdComponent(),
-                configuration.getFavicon().orElse(null),
-                getModInfo(configuration.isAnnounceForge())
-        );
-    }
+  private ServerPing createInitialPing() {
+    VelocityConfiguration configuration = server.getConfiguration();
+    ProtocolVersion shownVersion = ProtocolVersion.isSupported(connection.getProtocolVersion())
+        ? connection.getProtocolVersion() : ProtocolVersion.MAXIMUM_VERSION;
+    return new ServerPing(
+        new ServerPing.Version(shownVersion.getProtocol(),
+            "Velocity " + ProtocolVersion.SUPPORTED_VERSION_STRING),
+        new ServerPing.Players(server.getPlayerCount(), configuration.getShowMaxPlayers(),
+            ImmutableList.of()),
+        configuration.getMotdComponent(),
+        configuration.getFavicon().orElse(null),
+        getModInfo(configuration.isAnnounceForge())
+    );
+  }
 
-    private ModInfo getModInfo(boolean isAnnounceForge) {
-        for (String serverName : server.getConfiguration().getAttemptModInfoOrder()) {
-            Optional<RegisteredServer> registeredServer = server.getServer(serverName);
-            if (!registeredServer.isPresent()) continue;
-            try {
-                ServerPing serverPing = registeredServer.get().ping().get();
-                if (serverPing == null) continue;
-                Optional<ModInfo> modInfo = serverPing.getModinfo();
-                if (!modInfo.isPresent()) continue;
-                return modInfo.get();
-            } catch (InterruptedException | ExecutionException ignored) {
-            }
-        }
-        return isAnnounceForge ? ModInfo.DEFAULT : null;
+  private ModInfo getModInfo(boolean isAnnounceForge) {
+    for (String serverName : server.getConfiguration().getAttemptModInfoOrder()) {
+      Optional<RegisteredServer> registeredServer = server.getServer(serverName);
+      if (!registeredServer.isPresent()) continue;
+      try {
+        ServerPing serverPing = registeredServer.get().ping().get();
+        if (serverPing == null) continue;
+        Optional<ModInfo> modInfo = serverPing.getModinfo();
+        if (!modInfo.isPresent()) continue;
+        return modInfo.get();
+      } catch (InterruptedException | ExecutionException ignored) {
+      }
     }
+    return isAnnounceForge ? ModInfo.DEFAULT : null;
+  }
 
-    @Override
-    public boolean handle(LegacyPing packet) {
-        ServerPing initialPing = createInitialPing();
-        ProxyPingEvent event = new ProxyPingEvent(inboundWrapper, initialPing);
-        server.getEventManager().fire(event)
-                .thenRunAsync(() -> {
-                    connection.closeWith(LegacyDisconnect.fromServerPing(event.getPing(),
-                            packet.getVersion()));
-                }, connection.eventLoop());
-        return true;
-    }
+  @Override
+  public boolean handle(LegacyPing packet) {
+    ServerPing initialPing = createInitialPing();
+    ProxyPingEvent event = new ProxyPingEvent(inboundWrapper, initialPing);
+    server.getEventManager().fire(event)
+        .thenRunAsync(() -> {
+          connection.closeWith(LegacyDisconnect.fromServerPing(event.getPing(),
+              packet.getVersion()));
+        }, connection.eventLoop());
+    return true;
+  }
 
-    @Override
-    public boolean handle(StatusPing packet) {
-        connection.closeWith(packet);
-        return true;
-    }
+  @Override
+  public boolean handle(StatusPing packet) {
+    connection.closeWith(packet);
+    return true;
+  }
 
-    @Override
-    public boolean handle(StatusRequest packet) {
-        ServerPing initialPing = createInitialPing();
-        ProxyPingEvent event = new ProxyPingEvent(inboundWrapper, initialPing);
-        server.getEventManager().fire(event)
-                .thenRunAsync(
-                        () -> {
-                            StringBuilder json = new StringBuilder();
-                            VelocityServer.GSON.toJson(event.getPing(), json);
-                            connection.write(new StatusResponse(json));
-                        },
-                        connection.eventLoop());
-        return true;
-    }
+  @Override
+  public boolean handle(StatusRequest packet) {
+    ServerPing initialPing = createInitialPing();
+    ProxyPingEvent event = new ProxyPingEvent(inboundWrapper, initialPing);
+    server.getEventManager().fire(event)
+        .thenRunAsync(
+            () -> {
+              StringBuilder json = new StringBuilder();
+              VelocityServer.GSON.toJson(event.getPing(), json);
+              connection.write(new StatusResponse(json));
+            },
+            connection.eventLoop());
+    return true;
+  }
 
-    @Override
-    public void handleUnknown(ByteBuf buf) {
-        // what even is going on?
-        connection.close();
-    }
+  @Override
+  public void handleUnknown(ByteBuf buf) {
+    // what even is going on?
+    connection.close();
+  }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/StatusSessionHandler.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.velocitypowered.api.event.proxy.ProxyPingEvent;
 import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.InboundConnection;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerPing;
 import com.velocitypowered.api.util.ModInfo;
 import com.velocitypowered.proxy.VelocityServer;
@@ -17,70 +18,89 @@ import com.velocitypowered.proxy.protocol.packet.StatusRequest;
 import com.velocitypowered.proxy.protocol.packet.StatusResponse;
 import io.netty.buffer.ByteBuf;
 
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
 public class StatusSessionHandler implements MinecraftSessionHandler {
 
-  private final VelocityServer server;
-  private final MinecraftConnection connection;
-  private final InboundConnection inboundWrapper;
+    private final VelocityServer server;
+    private final MinecraftConnection connection;
+    private final InboundConnection inboundWrapper;
 
-  StatusSessionHandler(VelocityServer server, MinecraftConnection connection,
-      InboundConnection inboundWrapper) {
-    this.server = server;
-    this.connection = connection;
-    this.inboundWrapper = inboundWrapper;
-  }
+    StatusSessionHandler(VelocityServer server, MinecraftConnection connection,
+                         InboundConnection inboundWrapper) {
+        this.server = server;
+        this.connection = connection;
+        this.inboundWrapper = inboundWrapper;
+    }
 
-  private ServerPing createInitialPing() {
-    VelocityConfiguration configuration = server.getConfiguration();
-    ProtocolVersion shownVersion = ProtocolVersion.isSupported(connection.getProtocolVersion())
-        ? connection.getProtocolVersion() : ProtocolVersion.MAXIMUM_VERSION;
-    return new ServerPing(
-        new ServerPing.Version(shownVersion.getProtocol(),
-            "Velocity " + ProtocolVersion.SUPPORTED_VERSION_STRING),
-        new ServerPing.Players(server.getPlayerCount(), configuration.getShowMaxPlayers(),
-            ImmutableList.of()),
-        configuration.getMotdComponent(),
-        configuration.getFavicon().orElse(null),
-        configuration.isAnnounceForge() ? ModInfo.DEFAULT : null
-    );
-  }
+    private ServerPing createInitialPing() {
+        VelocityConfiguration configuration = server.getConfiguration();
+        ProtocolVersion shownVersion = ProtocolVersion.isSupported(connection.getProtocolVersion())
+                ? connection.getProtocolVersion() : ProtocolVersion.MAXIMUM_VERSION;
+        return new ServerPing(
+                new ServerPing.Version(shownVersion.getProtocol(),
+                        "Velocity " + ProtocolVersion.SUPPORTED_VERSION_STRING),
+                new ServerPing.Players(server.getPlayerCount(), configuration.getShowMaxPlayers(),
+                        ImmutableList.of()),
+                configuration.getMotdComponent(),
+                configuration.getFavicon().orElse(null),
+                getModInfo(configuration.isAnnounceForge())
+        );
+    }
 
-  @Override
-  public boolean handle(LegacyPing packet) {
-    ServerPing initialPing = createInitialPing();
-    ProxyPingEvent event = new ProxyPingEvent(inboundWrapper, initialPing);
-    server.getEventManager().fire(event)
-        .thenRunAsync(() -> {
-          connection.closeWith(LegacyDisconnect.fromServerPing(event.getPing(),
-              packet.getVersion()));
-        }, connection.eventLoop());
-    return true;
-  }
+    private ModInfo getModInfo(boolean isAnnounceForge) {
+        for (String serverName : server.getConfiguration().getAttemptModInfoOrder()) {
+            Optional<RegisteredServer> registeredServer = server.getServer(serverName);
+            if (!registeredServer.isPresent()) continue;
+            try {
+                ServerPing serverPing = registeredServer.get().ping().get();
+                if (serverPing == null) continue;
+                Optional<ModInfo> modInfo = serverPing.getModinfo();
+                if (!modInfo.isPresent()) continue;
+                return modInfo.get();
+            } catch (InterruptedException | ExecutionException ignored) {
+            }
+        }
+        return isAnnounceForge ? ModInfo.DEFAULT : null;
+    }
 
-  @Override
-  public boolean handle(StatusPing packet) {
-    connection.closeWith(packet);
-    return true;
-  }
+    @Override
+    public boolean handle(LegacyPing packet) {
+        ServerPing initialPing = createInitialPing();
+        ProxyPingEvent event = new ProxyPingEvent(inboundWrapper, initialPing);
+        server.getEventManager().fire(event)
+                .thenRunAsync(() -> {
+                    connection.closeWith(LegacyDisconnect.fromServerPing(event.getPing(),
+                            packet.getVersion()));
+                }, connection.eventLoop());
+        return true;
+    }
 
-  @Override
-  public boolean handle(StatusRequest packet) {
-    ServerPing initialPing = createInitialPing();
-    ProxyPingEvent event = new ProxyPingEvent(inboundWrapper, initialPing);
-    server.getEventManager().fire(event)
-        .thenRunAsync(
-            () -> {
-              StringBuilder json = new StringBuilder();
-              VelocityServer.GSON.toJson(event.getPing(), json);
-              connection.write(new StatusResponse(json));
-            },
-            connection.eventLoop());
-    return true;
-  }
+    @Override
+    public boolean handle(StatusPing packet) {
+        connection.closeWith(packet);
+        return true;
+    }
 
-  @Override
-  public void handleUnknown(ByteBuf buf) {
-    // what even is going on?
-    connection.close();
-  }
+    @Override
+    public boolean handle(StatusRequest packet) {
+        ServerPing initialPing = createInitialPing();
+        ProxyPingEvent event = new ProxyPingEvent(inboundWrapper, initialPing);
+        server.getEventManager().fire(event)
+                .thenRunAsync(
+                        () -> {
+                            StringBuilder json = new StringBuilder();
+                            VelocityServer.GSON.toJson(event.getPing(), json);
+                            connection.write(new StatusResponse(json));
+                        },
+                        connection.eventLoop());
+        return true;
+    }
+
+    @Override
+    public void handleUnknown(ByteBuf buf) {
+        // what even is going on?
+        connection.close();
+    }
 }


### PR DESCRIPTION
This PR adds support for retrieving the `ModInfo` part of a ping from a specified server to forward it to the client via the proxy. This solves an issue with modded servers having a red X shown along with "Incompatible: 0 mods present" instead of the correct amount.