### PR TITLE
Completely clear legacy tablist on server switch

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/tablist/VelocityTabListLegacy.java
@@ -52,6 +52,7 @@ public class VelocityTabListLegacy extends VelocityTabList {
           Collections.singletonList(PlayerListItem.Item.from(value))));
     }
     entries.clear();
+    nameMapping.clear();
   }
 
   @Override


### PR DESCRIPTION
I forgot to clear the name mapping upon server switch, which lead to weird duplicate entries.