### PR TITLE
Clean server name keys before attempting to register

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -467,7 +467,7 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
         Map<String, String> servers = new HashMap<>();
         for (Map.Entry<String, Object> entry : toml.entrySet()) {
           if (entry.getValue() instanceof String) {
-            servers.put(entry.getKey(), (String) entry.getValue());
+            servers.put(cleanServerName(entry.getKey()), (String) entry.getValue());
           } else {
             if (!entry.getKey().equalsIgnoreCase("try")) {
               throw new IllegalArgumentException(
@@ -499,6 +499,19 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
 
     public void setAttemptConnectionOrder(List<String> attemptConnectionOrder) {
       this.attemptConnectionOrder = attemptConnectionOrder;
+    }
+
+    /**
+     * TOML requires keys to match a regex of {@code [A-Za-z0-9_-]} unless it is wrapped in
+     * quotes; however, the TOML parser returns the key with the quotes so we need to clean the
+     * server name before we pass it onto server registration to keep proper server name behavior.
+     *
+     * @param name the server name to clean
+     *
+     * @return the cleaned server name
+     */
+    private String cleanServerName(String name) {
+      return name.replace("\"", "");
     }
 
     @Override


### PR DESCRIPTION
Server names that don't match [A-Za-z0-9_-] fail to parse unless wrapped in quotes. The TOML api leaves these quotes in place when reading the key which leads to unintended name behavior.