### PR TITLE
Fire DisconnectEvent in ConnectedPlayer#disconnect

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -279,6 +279,9 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
 
   @Override
   public void disconnect(Component reason) {
+    boolean isConnected = server.getPlayer(this.getUniqueId()).isPresent();
+    server.getEventManager().fireAndForget(new DisconnectEvent(this, !isConnected));
+
     logger.info("{} has disconnected: {}", this,
         LegacyComponentSerializer.legacy().serialize(reason));
     connection.closeWith(Disconnect.create(reason));


### PR DESCRIPTION
I noticed that in some cases (see: proxy shutdown), DisconnectEvent will never be called for a player whenever they're disconnected by the proxy.