### PR TITLE
Passed the used alias to the command executor

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/Command.java
+++ b/api/src/main/java/com/velocitypowered/api/command/Command.java
@@ -14,9 +14,10 @@ public interface Command {
    * Executes the command for the specified {@link CommandSource}.
    *
    * @param source the source of this command
+   * @param alias the alias used to execute this command
    * @param args the arguments for this command
    */
-  void execute(CommandSource source, String @NonNull [] args);
+  void execute(CommandSource source, String alias, String @NonNull [] args);
 
   /**
    * Provides tab complete suggestions for a command for a specified {@link CommandSource}.

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/GlistCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/GlistCommand.java
@@ -24,7 +24,7 @@ public class GlistCommand implements Command {
   }
 
   @Override
-  public void execute(CommandSource source, String @NonNull [] args) {
+  public void execute(CommandSource source, String alias, String @NonNull [] args) {
     if (args.length == 0) {
       sendTotalProxyCount(source);
       source.sendMessage(

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/ServerCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/ServerCommand.java
@@ -28,7 +28,7 @@ public class ServerCommand implements Command {
   }
 
   @Override
-  public void execute(CommandSource source, String @NonNull [] args) {
+  public void execute(CommandSource source, String alias, String @NonNull [] args) {
     if (!(source instanceof Player)) {
       source.sendMessage(TextComponent.of("Only players may run this command.", TextColor.RED));
       return;

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/ShutdownCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/ShutdownCommand.java
@@ -16,7 +16,7 @@ public class ShutdownCommand implements Command {
   }
 
   @Override
-  public void execute(CommandSource source, String @NonNull [] args) {
+  public void execute(CommandSource source, String alias, String @NonNull [] args) {
     server.shutdown(true);
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommand.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommand.java
@@ -53,7 +53,7 @@ public class VelocityCommand implements Command {
   }
 
   @Override
-  public void execute(CommandSource source, String @NonNull [] args) {
+  public void execute(CommandSource source, String alias, String @NonNull [] args) {
     if (args.length == 0) {
       usage(source);
       return;
@@ -66,7 +66,7 @@ public class VelocityCommand implements Command {
     }
     @SuppressWarnings("nullness")
     String[] actualArgs = Arrays.copyOfRange(args, 1, args.length);
-    command.execute(source, actualArgs);
+    command.execute(source, alias, actualArgs);
   }
 
   @Override
@@ -120,7 +120,7 @@ public class VelocityCommand implements Command {
     }
 
     @Override
-    public void execute(CommandSource source, String @NonNull [] args) {
+    public void execute(CommandSource source, String alias, String @NonNull [] args) {
       try {
         if (server.reloadConfiguration()) {
           source.sendMessage(TextComponent.of("Configuration reloaded.", TextColor.GREEN));
@@ -152,7 +152,7 @@ public class VelocityCommand implements Command {
     }
 
     @Override
-    public void execute(CommandSource source, String @NonNull [] args) {
+    public void execute(CommandSource source, String alias, String @NonNull [] args) {
       if (args.length != 0) {
         source.sendMessage(TextComponent.of("/velocity version", TextColor.RED));
         return;
@@ -205,7 +205,7 @@ public class VelocityCommand implements Command {
     }
 
     @Override
-    public void execute(CommandSource source, String @NonNull [] args) {
+    public void execute(CommandSource source, String alias, String @NonNull [] args) {
       if (args.length != 0) {
         source.sendMessage(TextComponent.of("/velocity plugins", TextColor.RED));
         return;

--- a/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/command/VelocityCommandManager.java
@@ -59,7 +59,7 @@ public class VelocityCommandManager implements CommandManager {
         return false;
       }
 
-      command.execute(source, actualArgs);
+      command.execute(source, alias, actualArgs);
       return true;
     } catch (Exception e) {
       throw new RuntimeException("Unable to invoke command " + cmdLine + " for " + source, e);


### PR DESCRIPTION
Imagine having a command with an alias called message and another alias called msg
Depending on the alias the user used to execute this command, a usage message could
be customized to show the exact same alias as the user used to execute.

For example:

	/message
	would result in: Usage: /message <Player> <Message>

	/msg
	would result in: Usage: /msg <Player> <Message>