### PR TITLE
Fix config formatting

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -65,21 +65,21 @@ public class VelocityConfiguration extends AnnotatedConfig implements ProxyConfi
   @Comment({
       "Should we forward IP addresses and other data to backend servers?",
       "Available options:",
-      "- \"none\":   No forwarding will be done. All players will appear to be connecting from the",
-      "            proxy and will have offline-mode UUIDs.",
-      "- \"legacy\": Forward player IPs and UUIDs in a BungeeCord-compatible format. Use this if",
-      "            you run servers using Minecraft 1.12 or lower.",
+      "- \"none\":        No forwarding will be done. All players will appear to be connecting",
+      "                 from the proxy and will have offline-mode UUIDs.",
+      "- \"legacy\":      Forward player IPs and UUIDs in a BungeeCord-compatible format. Use this",
+      "                 if you run servers using Minecraft 1.12 or lower.",
       "- \"bungeeguard\": Forward player IPs and UUIDs in a format supported by the BungeeGuard",
-      "            plugin. Use this if you run servers using Minecraft 1.12 or lower, and are",
-      "            unable to implement network level firewalling (on a shared host).",
-      "- \"modern\": Forward player IPs and UUIDs as part of the login process using Velocity's ",
-      "            native forwarding. Only applicable for Minecraft 1.13 or higher."
+      "                 plugin. Use this if you run servers using Minecraft 1.12 or lower, and are",
+      "                 unable to implement network level firewalling (on a shared host).",
+      "- \"modern\":      Forward player IPs and UUIDs as part of the login process using",
+      "                 Velocity's native forwarding. Only applicable for Minecraft 1.13 or higher."
   })
   @ConfigKey("player-info-forwarding-mode")
   private PlayerInfoForwarding playerInfoForwardingMode = PlayerInfoForwarding.NONE;
 
   @StringAsBytes
-  @Comment("If you are using modern IP forwarding, configure an unique secret here.")
+  @Comment("If you are using modern or BungeeGuard IP forwarding, configure an unique secret here.")
   @ConfigKey("forwarding-secret")
   private byte[] forwardingSecret = generateRandomString(12).getBytes(StandardCharsets.UTF_8);
 


### PR DESCRIPTION
before:
```toml
# Should we forward IP addresses and other data to backend servers?
# Available options:
# - "none":   No forwarding will be done. All players will appear to be connecting from the
#             proxy and will have offline-mode UUIDs.
# - "legacy": Forward player IPs and UUIDs in a BungeeCord-compatible format. Use this if
#             you run servers using Minecraft 1.12 or lower.
# - "bungeeguard": Forward player IPs and UUIDs in a format supported by the BungeeGuard
#             plugin. Use this if you run servers using Minecraft 1.12 or lower, and are
#             unable to implement network level firewalling (on a shared host).
# - "modern": Forward player IPs and UUIDs as part of the login process using Velocity's
#             native forwarding. Only applicable for Minecraft 1.13 or higher.
player-info-forwarding-mode = "NONE"
```

after:
```toml
# Should we forward IP addresses and other data to backend servers?
# Available options:
# - "none":        No forwarding will be done. All players will appear to be connecting
#                  from the proxy and will have offline-mode UUIDs.
# - "legacy":      Forward player IPs and UUIDs in a BungeeCord-compatible format. Use this
#                  if you run servers using Minecraft 1.12 or lower.
# - "bungeeguard": Forward player IPs and UUIDs in a format supported by the BungeeGuard
#                  plugin. Use this if you run servers using Minecraft 1.12 or lower, and are
#                  unable to implement network level firewalling (on a shared host).
# - "modern":      Forward player IPs and UUIDs as part of the login process using
#                  Velocity's native forwarding. Only applicable for Minecraft 1.13 or higher.
player-info-forwarding-mode = "NONE"
```