### PR TITLE
Add async suggestions

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/command/Command.java
+++ b/api/src/main/java/com/velocitypowered/api/command/Command.java
@@ -2,6 +2,7 @@ package com.velocitypowered.api.command;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -27,6 +28,18 @@ public interface Command {
    */
   default List<String> suggest(CommandSource source, String @NonNull [] currentArgs) {
     return ImmutableList.of();
+  }
+
+  /**
+   * Provides tab complete suggestions for a command for a specified {@link CommandSource}.
+   *
+   * @param source the source to run the command for
+   * @param currentArgs the current, partial arguments for this command
+   * @return tab complete suggestions
+   */
+  default CompletableFuture<List<String>> suggestAsync(CommandSource source,
+      String @NonNull [] currentArgs) {
+    return CompletableFuture.completedFuture(suggest(source, currentArgs));
   }
 
   /**

--- a/api/src/main/java/com/velocitypowered/api/command/RawCommand.java
+++ b/api/src/main/java/com/velocitypowered/api/command/RawCommand.java
@@ -2,6 +2,7 @@ package com.velocitypowered.api.command;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
@@ -29,13 +30,19 @@ public interface RawCommand extends Command {
    * @param currentLine the current, partial command line for this command
    * @return tab complete suggestions
    */
-  default List<String> suggest(CommandSource source, String currentLine) {
-    return ImmutableList.of();
+  default CompletableFuture<List<String>> suggest(CommandSource source, String currentLine) {
+    return CompletableFuture.completedFuture(ImmutableList.of());
+  }
+
+  @Override
+  default CompletableFuture<List<String>> suggestAsync(CommandSource source,
+      String @NonNull [] currentArgs) {
+    return suggest(source, String.join(" ", currentArgs));
   }
 
   @Override
   default List<String> suggest(CommandSource source, String @NonNull [] currentArgs) {
-    return suggest(source, String.join(" ", currentArgs));
+    return suggestAsync(source, currentArgs).join();
   }
 
   @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/console/VelocityConsole.java
@@ -73,7 +73,8 @@ public final class VelocityConsole extends SimpleTerminalConsole implements Cons
           try {
             boolean isCommand = parsedLine.line().indexOf(' ') == -1;
             List<String> offers = this.server.getCommandManager()
-                .offerSuggestions(this, parsedLine.line());
+                .offerSuggestions(this, parsedLine.line())
+                .join(); // Console doesn't get harmed much by this...
             for (String offer : offers) {
               if (isCommand) {
                 list.add(new Candidate(offer.substring(1)));


### PR DESCRIPTION
Fairly simple.

To use them, the developer should still implement sync ones for plugins which depends on others' suggestions. Whether this includes data fetched from e.g. a database is up to them.