### PR TITLE
Update VelocityServerConnection.java

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/VelocityServerConnection.java
@@ -139,7 +139,7 @@ public class VelocityServerConnection implements MinecraftConnectionAssociation,
       byte[] secret = server.getConfiguration().getForwardingSecret();
       handshake.setServerAddress(createBungeeGuardForwardingAddress(secret));
     } else if (proxyPlayer.getConnection().getType() == ConnectionTypes.LEGACY_FORGE) {
-      handshake.setServerAddress(handshake.getServerAddress() + HANDSHAKE_HOSTNAME_TOKEN);
+      handshake.setServerAddress(HANDSHAKE_HOSTNAME_TOKEN);
     } else {
       handshake.setServerAddress(registeredServer.getServerInfo().getAddress().getHostString());
     }


### PR DESCRIPTION
If the serverAddress in `handshake` is empty, why do we prepend it to the HANDSHAKE_HOSTNAME_TOKEN?
Or should it be
```
handshake.setServerAddress(registeredServer.getServerInfo().getAddress().getHostString() + HANDSHAKE_HOSTNAME_TOKEN);
```