### PR TITLE
Make initial read timeout configurable

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -150,4 +150,12 @@ public interface ProxyConfig {
    * @return read timeout (in milliseconds)
    */
   int getReadTimeout();
+
+
+  /**
+   * Get how long this proxy will wait until performing an initial read timeout.
+   *
+   * @return read timeout (in milliseconds)
+   */
+  int getInitialReadTimeout();
 }

--- a/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/config/ProxyConfig.java
@@ -151,7 +151,6 @@ public interface ProxyConfig {
    */
   int getReadTimeout();
 
-
   /**
    * Get how long this proxy will wait until performing an initial read timeout.
    *

--- a/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/config/VelocityConfiguration.java
@@ -318,6 +318,11 @@ public class VelocityConfiguration implements ProxyConfig {
     return advanced.getReadTimeout();
   }
 
+  @Override
+  public int getInitialReadTimeout() {
+    return advanced.getInitialReadTimeout();
+  }
+
   public boolean isProxyProtocol() {
     return advanced.isProxyProtocol();
   }
@@ -592,6 +597,7 @@ public class VelocityConfiguration implements ProxyConfig {
     private boolean failoverOnUnexpectedServerDisconnect = true;
     private boolean announceProxyCommands = true;
     private boolean logCommandExecutions = false;
+    private int initialReadTimeout = 3000;
 
     private Advanced() {
     }
@@ -611,6 +617,7 @@ public class VelocityConfiguration implements ProxyConfig {
             .getOrElse("failover-on-unexpected-server-disconnect", true);
         this.announceProxyCommands = config.getOrElse("announce-proxy-commands", true);
         this.logCommandExecutions = config.getOrElse("log-command-executions", false);
+        this.initialReadTimeout = config.getIntOrElse("initial-read-timeout", 3000);
       }
     }
 
@@ -660,6 +667,10 @@ public class VelocityConfiguration implements ProxyConfig {
 
     public boolean isLogCommandExecutions() {
       return logCommandExecutions;
+    }
+
+    public int getInitialReadTimeout() {
+      return initialReadTimeout;
     }
 
     @Override

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/LoginSessionHandler.java
@@ -25,6 +25,7 @@ import com.velocitypowered.proxy.config.PlayerInfoForwarding;
 import com.velocitypowered.proxy.config.VelocityConfiguration;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
+import com.velocitypowered.proxy.network.Connections;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.Disconnect;
 import com.velocitypowered.proxy.protocol.packet.EncryptionRequest;
@@ -34,6 +35,7 @@ import com.velocitypowered.proxy.protocol.packet.ServerLoginSuccess;
 import com.velocitypowered.proxy.protocol.packet.SetCompression;
 import com.velocitypowered.proxy.util.VelocityMessages;
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.net.InetSocketAddress;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
@@ -43,6 +45,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -198,6 +201,12 @@ public class LoginSessionHandler implements MinecraftSessionHandler {
   }
 
   private void initializePlayer(GameProfile profile, boolean onlineMode) {
+    // Restore normal timeout for connection.
+    mcConnection.getChannel().pipeline()
+            .replace(Connections.READ_TIMEOUT, Connections.READ_TIMEOUT,
+                    new ReadTimeoutHandler(server.getConfiguration().getReadTimeout(),
+                            TimeUnit.MILLISECONDS));
+
     // Some connection types may need to alter the game profile.
     profile = mcConnection.getType().addGameProfileTokensIfRequired(profile,
         server.getConfiguration().getPlayerInfoForwardingMode());

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/ServerChannelInitializer.java
@@ -37,7 +37,7 @@ public class ServerChannelInitializer extends ChannelInitializer<Channel> {
   protected void initChannel(final Channel ch) {
     ch.pipeline()
         .addLast(READ_TIMEOUT,
-            new ReadTimeoutHandler(this.server.getConfiguration().getReadTimeout(),
+            new ReadTimeoutHandler(this.server.getConfiguration().getInitialReadTimeout(),
                 TimeUnit.MILLISECONDS))
         .addLast(LEGACY_PING_DECODER, new LegacyPingDecoder())
         .addLast(FRAME_DECODER, new MinecraftVarintFrameDecoder())

--- a/proxy/src/main/resources/default-velocity.toml
+++ b/proxy/src/main/resources/default-velocity.toml
@@ -105,6 +105,9 @@ connection-timeout = 5000
 # Specify a read timeout for connections here. The default is 30 seconds.
 read-timeout = 30000
 
+# Specify an initial read timeout for connections here. The default is 3 seconds.
+initial-read-timeout = 3000
+
 # Enables compatibility with HAProxy.
 proxy-protocol = false
 


### PR DESCRIPTION
Made it so initial timeout for connections is configurable.
Timeout is restored back later when user switches to PLAY state.