### PR TITLE
Actually solve framing issues.

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftConnection.java
@@ -27,6 +27,7 @@ import com.velocitypowered.proxy.protocol.netty.MinecraftCompressDecoder;
 import com.velocitypowered.proxy.protocol.netty.MinecraftCompressEncoder;
 import com.velocitypowered.proxy.protocol.netty.MinecraftDecoder;
 import com.velocitypowered.proxy.protocol.netty.MinecraftEncoder;
+import com.velocitypowered.proxy.util.NettyUtil;
 import com.velocitypowered.proxy.util.except.QuietDecoderException;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -169,7 +170,9 @@ public class MinecraftConnection extends ChannelInboundHandlerAdapter {
         }
       }
 
-      ctx.close();
+      Channel ch = ctx.channel();
+      NettyUtil.insertDiscard(ch);
+      ch.close();
     }
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/Connections.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/Connections.java
@@ -15,6 +15,7 @@ public class Connections {
   public static final String MINECRAFT_DECODER = "minecraft-decoder";
   public static final String MINECRAFT_ENCODER = "minecraft-encoder";
   public static final String READ_TIMEOUT = "read-timeout";
+  public static final String DISCARD = "discard";
 
   private Connections() {
     throw new AssertionError();

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftDecoder.java
@@ -9,6 +9,7 @@ import com.velocitypowered.proxy.util.except.QuietDecoderException;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.CorruptedFrameException;
 
 public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
@@ -56,14 +57,16 @@ public class MinecraftDecoder extends ChannelInboundHandlerAdapter {
         try {
           packet.decode(buf, direction, registry.version);
         } catch (Exception e) {
-          ctx.channel().pipeline().get(MinecraftVarintFrameDecoder.class)
-                  .setSingleDecode(true);
+          ChannelPipeline pipeline = ctx.pipeline();
+          pipeline.get(MinecraftVarintFrameDecoder.class).setSingleDecode(true);
+          pipeline.get(LegacyPingDecoder.class).setSingleDecode(true);
           throw handleDecodeFailure(e, packet, packetId);
         }
 
         if (buf.isReadable()) {
-          ctx.channel().pipeline().get(MinecraftVarintFrameDecoder.class)
-                  .setSingleDecode(true);
+          ChannelPipeline pipeline = ctx.pipeline();
+          pipeline.get(MinecraftVarintFrameDecoder.class).setSingleDecode(true);
+          pipeline.get(LegacyPingDecoder.class).setSingleDecode(true);
           throw handleNotReadEnough(packet, packetId);
         }
         ctx.fireChannelRead(packet);

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintFrameDecoder.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/MinecraftVarintFrameDecoder.java
@@ -17,11 +17,6 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
 
   @Override
   protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
-    if (!ctx.channel().isActive()) {
-      in.skipBytes(in.readableBytes());
-      return;
-    }
-
     reader.reset();
 
     int varintEnd = in.forEachByte(reader);
@@ -33,6 +28,7 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
 
     if (reader.result == DecodeResult.SUCCESS) {
       if (reader.readVarint < 0) {
+        setSingleDecode(true);
         throw BAD_LENGTH_CACHED;
       } else if (reader.readVarint == 0) {
         // skip over the empty packet and ignore it
@@ -47,6 +43,7 @@ public class MinecraftVarintFrameDecoder extends ByteToMessageDecoder {
         }
       }
     } else if (reader.result == DecodeResult.TOO_BIG) {
+      setSingleDecode( true );
       throw VARINT_BIG_CACHED;
     }
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/NettyUtil.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/NettyUtil.java
@@ -1,0 +1,42 @@
+package com.velocitypowered.proxy.util;
+
+import com.velocitypowered.proxy.network.Connections;
+import com.velocitypowered.proxy.util.except.QuietPromiseException;
+import io.netty.channel.*;
+import io.netty.util.ReferenceCountUtil;
+
+public final class NettyUtil {
+    private static final DiscardHandler INSTANCE = new DiscardHandler();
+
+    private NettyUtil() {
+        throw new AssertionError();
+    }
+
+    /**
+     * This is needed because {@link io.netty.handler.codec.ByteToMessageDecoder} will continue to read messages, even tho
+     * {@link io.netty.handler.codec.ByteToMessageDecoder#setSingleDecode(boolean)} was set to true.
+     */
+    public static void insertDiscard(Channel channel) {
+        ChannelPipeline pipeline = channel.pipeline();
+        if (pipeline.first() != INSTANCE) {
+            pipeline.addFirst(Connections.DISCARD, INSTANCE);
+        }
+    }
+
+    @ChannelHandler.Sharable
+    public static final class DiscardHandler extends ChannelOutboundHandlerAdapter {
+        private static final QuietPromiseException EXCEPTION = new QuietPromiseException();
+
+        @Override
+        public void read(ChannelHandlerContext ctx) throws Exception { }
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            ReferenceCountUtil.release(msg);
+            promise.setFailure(EXCEPTION);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception { }
+    }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/except/QuietDecoderException.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/except/QuietDecoderException.java
@@ -13,7 +13,12 @@ public class QuietDecoderException extends DecoderException {
   }
 
   @Override
-  public synchronized Throwable fillInStackTrace() {
+  public Throwable fillInStackTrace() {
+    return this;
+  }
+
+  @Override
+  public Throwable initCause(Throwable cause) {
     return this;
   }
 }

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/except/QuietPromiseException.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/except/QuietPromiseException.java
@@ -1,0 +1,17 @@
+package com.velocitypowered.proxy.util.except;
+
+/**
+ * A special-purpose exception thrown when we want to indicate that promise failed but do not want
+ * to see a large stack trace in logs.
+ */
+public final class QuietPromiseException extends Exception {
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+
+    @Override
+    public Throwable initCause(Throwable cause) {
+        return this;
+    }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/util/except/QuietRuntimeException.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/util/except/QuietRuntimeException.java
@@ -11,7 +11,12 @@ public class QuietRuntimeException extends RuntimeException {
   }
 
   @Override
-  public synchronized Throwable fillInStackTrace() {
+  public Throwable fillInStackTrace() {
+    return this;
+  }
+
+  @Override
+  public Throwable initCause(Throwable cause) {
     return this;
   }
 }


### PR DESCRIPTION
This was initialy reported in https://github.com/netty/netty/issues/10417
In fact, the problem is that other decoders does not know about frame-decoder, so it continues to read. This PR makes it so packet decoder notifies varint decoder about fatal errors, causing it to stop reading.

See https://github.com/SpigotMC/BungeeCord/pull/2908#issuecomment-665840788 for results