### PR TITLE
Add shutdown methods to ProxyServer

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
+++ b/api/src/main/java/com/velocitypowered/api/proxy/ProxyServer.java
@@ -19,12 +19,25 @@ import java.util.Optional;
 import java.util.UUID;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * Provides an interface to a Minecraft server proxy.
  */
 public interface ProxyServer extends Audience {
+
+  /**
+   * Shuts down the proxy, kicking players with the specified {@param reason}.
+   *
+   * @param reason message to kick online players with
+   */
+  void shutdown(TextComponent reason);
+
+  /**
+   * Shuts down the proxy, kicking players with the default reason.
+   */
+  void shutdown();
 
   /**
    * Retrieves the player currently connected to this proxy by their Minecraft username. The search

--- a/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/VelocityServer.java
@@ -453,6 +453,16 @@ public class VelocityServer implements ProxyServer, ForwardingAudience {
     shutdown(explicitExit, TextComponent.of("Proxy shutting down."));
   }
 
+  @Override
+  public void shutdown(TextComponent reason) {
+    shutdown(true, reason);
+  }
+
+  @Override
+  public void shutdown() {
+    shutdown(true);
+  }
+
   public AsyncHttpClient getAsyncHttpClient() {
     return cm.getHttpClient();
   }


### PR DESCRIPTION
Add shutdown methods to the ProxyServer interface. I left out the `explicit` parameter because it seemed like an unnecessary complexity for the API.