### PR TITLE
Add dataAsInputStream() to PluginMessageEvent

### DIFF
--- a/api/src/main/java/com/velocitypowered/api/event/connection/PluginMessageEvent.java
+++ b/api/src/main/java/com/velocitypowered/api/event/connection/PluginMessageEvent.java
@@ -9,6 +9,7 @@ import com.velocitypowered.api.proxy.ServerConnection;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.api.proxy.messages.ChannelMessageSink;
 import com.velocitypowered.api.proxy.messages.ChannelMessageSource;
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 
 /**
@@ -64,6 +65,10 @@ public final class PluginMessageEvent implements ResultedEvent<PluginMessageEven
 
   public byte[] getData() {
     return Arrays.copyOf(data, data.length);
+  }
+
+  public ByteArrayInputStream dataAsInputStream() {
+    return new ByteArrayInputStream(data);
   }
 
   public ByteArrayDataInput dataAsDataStream() {


### PR DESCRIPTION
Adds the method `dataAsInputStream()` to `PluginMessageEvent`. This allows for multiple reads of the data without unnecessary copying. Note that `ByteArrayInputStream` does not allow modifications of the underlying array, so it is still safe.