### PR TITLE
Skip unnecessary decompression of compressed packet from server/client

### DIFF
--- a/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
+++ b/native/src/main/java/com/velocitypowered/natives/compression/JavaVelocityCompressor.java
@@ -16,12 +16,14 @@ public class JavaVelocityCompressor implements VelocityCompressor {
   private final Deflater deflater;
   private final Inflater inflater;
   private final byte[] buf;
+  private final byte[] varintBuffer;
   private boolean disposed = false;
 
   private JavaVelocityCompressor(int level) {
     this.deflater = new Deflater(level);
     this.inflater = new Inflater();
     this.buf = new byte[ZLIB_BUFFER_SIZE];
+    this.varintBuffer = new byte[5];
   }
 
   @Override
@@ -37,10 +39,12 @@ public class JavaVelocityCompressor implements VelocityCompressor {
       inflater.setInput(inData);
     }
 
+    byte[] buffer = destination.capacity() == varintBuffer.length ? varintBuffer : buf;
+
     while (!inflater.finished() && inflater.getBytesRead() < available) {
       ensureMaxSize(destination, max);
-      int read = inflater.inflate(buf);
-      destination.writeBytes(buf, 0, read);
+      int read = inflater.inflate(buffer);
+      destination.writeBytes(buffer, 0, read);
     }
     inflater.reset();
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/MinecraftSessionHandler.java
@@ -1,6 +1,5 @@
 package com.velocitypowered.proxy.connection;
 
-import com.velocitypowered.proxy.protocol.MinecraftPacket;
 import com.velocitypowered.proxy.protocol.packet.AvailableCommands;
 import com.velocitypowered.proxy.protocol.packet.BossBar;
 import com.velocitypowered.proxy.protocol.packet.Chat;
@@ -38,8 +37,12 @@ public interface MinecraftSessionHandler {
     return false;
   }
 
-  default void handleGeneric(MinecraftPacket packet) {
+  default void handleGeneric(Object packet) {
 
+  }
+
+  default boolean shouldHandle(int packetId) {
+    return true;
   }
 
   default void handleUnknown(ByteBuf buf) {

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/backend/BackendPlaySessionHandler.java
@@ -5,20 +5,17 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
-import com.velocitypowered.api.network.ProtocolVersion;
 import com.velocitypowered.api.proxy.messages.ChannelIdentifier;
 import com.velocitypowered.proxy.VelocityServer;
 import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.client.ClientPlaySessionHandler;
-import com.velocitypowered.proxy.connection.forge.legacy.LegacyForgeConstants;
 import com.velocitypowered.proxy.connection.util.ConnectionMessages;
-import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils.Direction;
 import com.velocitypowered.proxy.protocol.packet.AvailableCommands;
 import com.velocitypowered.proxy.protocol.packet.AvailableCommands.ProtocolSuggestionProvider;
 import com.velocitypowered.proxy.protocol.packet.BossBar;
 import com.velocitypowered.proxy.protocol.packet.Disconnect;
-import com.velocitypowered.proxy.protocol.packet.JoinGame;
 import com.velocitypowered.proxy.protocol.packet.KeepAlive;
 import com.velocitypowered.proxy.protocol.packet.PlayerListItem;
 import com.velocitypowered.proxy.protocol.packet.PluginMessage;
@@ -60,6 +57,19 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
       return true;
     }
     return false;
+  }
+
+  @Override
+  public boolean shouldHandle(int packetId) {
+    MinecraftConnection connection = serverConn.getConnection();
+
+    if (connection != null) {
+      return Direction.CLIENTBOUND
+          .getProtocolRegistry(connection.getState(), connection.getProtocolVersion())
+          .containsInboundPacketId(packetId);
+    }
+
+    return true;
   }
 
   @Override
@@ -162,7 +172,7 @@ public class BackendPlaySessionHandler implements MinecraftSessionHandler {
   }
 
   @Override
-  public void handleGeneric(MinecraftPacket packet) {
+  public void handleGeneric(Object packet) {
     playerConnection.write(packet);
   }
 

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ClientPlaySessionHandler.java
@@ -13,7 +13,7 @@ import com.velocitypowered.proxy.connection.MinecraftConnection;
 import com.velocitypowered.proxy.connection.MinecraftSessionHandler;
 import com.velocitypowered.proxy.connection.backend.BackendConnectionPhases;
 import com.velocitypowered.proxy.connection.backend.VelocityServerConnection;
-import com.velocitypowered.proxy.protocol.MinecraftPacket;
+import com.velocitypowered.proxy.protocol.ProtocolUtils.Direction;
 import com.velocitypowered.proxy.protocol.StateRegistry;
 import com.velocitypowered.proxy.protocol.packet.BossBar;
 import com.velocitypowered.proxy.protocol.packet.Chat;
@@ -76,6 +76,14 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
       player.getMinecraftConnection().write(register);
       player.getKnownChannels().addAll(channels);
     }
+  }
+
+  @Override
+  public boolean shouldHandle(int packetId) {
+    MinecraftConnection playerConnection = player.getMinecraftConnection();
+    return Direction.SERVERBOUND
+        .getProtocolRegistry(playerConnection.getState(), playerConnection.getProtocolVersion())
+        .containsInboundPacketId(packetId);
   }
 
   @Override
@@ -252,7 +260,7 @@ public class ClientPlaySessionHandler implements MinecraftSessionHandler {
   }
 
   @Override
-  public void handleGeneric(MinecraftPacket packet) {
+  public void handleGeneric(Object packet) {
     VelocityServerConnection serverConnection = player.getConnectedServer();
     if (serverConnection == null) {
       // No server connection yet, probably transitioning.

--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/HandshakeSessionHandler.java
@@ -165,7 +165,7 @@ public class HandshakeSessionHandler implements MinecraftSessionHandler {
   }
 
   @Override
-  public void handleGeneric(MinecraftPacket packet) {
+  public void handleGeneric(Object packet) {
     // Unknown packet received. Better to close the connection.
     connection.close();
   }

--- a/proxy/src/main/java/com/velocitypowered/proxy/network/Connections.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/network/Connections.java
@@ -6,6 +6,7 @@ public class Connections {
   public static final String CIPHER_ENCODER = "cipher-encoder";
   public static final String COMPRESSION_DECODER = "compression-decoder";
   public static final String COMPRESSION_ENCODER = "compression-encoder";
+  public static final String SKIPPED_PACKET_WRITER = "skipped-packet-writer";
   public static final String FLOW_HANDLER = "flow-handler";
   public static final String FRAME_DECODER = "frame-decoder";
   public static final String FRAME_ENCODER = "frame-encoder";

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/SkippedCompressedPacket.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/SkippedCompressedPacket.java
@@ -1,0 +1,23 @@
+package com.velocitypowered.proxy.protocol;
+
+import io.netty.buffer.ByteBuf;
+
+public class SkippedCompressedPacket {
+
+  public final int packetId;
+  public final int packetLength;
+  public final ByteBuf buffer;
+
+  /**
+   * Creates a wrapper for compressed Minecraft packet.
+   *
+   * @param packetId     - decompressed id of the packet
+   * @param packetLength - uncompressed packet size
+   * @param buffer       - compressed packet data
+   */
+  public SkippedCompressedPacket(int packetId, int packetLength, ByteBuf buffer) {
+    this.packetId = packetId;
+    this.packetLength = packetLength;
+    this.buffer = buffer;
+  }
+}

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/StateRegistry.java
@@ -359,6 +359,10 @@ public enum StateRegistry {
         return supplier.get();
       }
 
+      public boolean containsInboundPacketId(final int id) {
+        return this.packetIdToSupplier.containsKey(id);
+      }
+
       /**
        * Attempts to look up the packet ID for an {@code packet}.
        *

--- a/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/SkippedPacketWriter.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/protocol/netty/SkippedPacketWriter.java
@@ -1,0 +1,25 @@
+package com.velocitypowered.proxy.protocol.netty;
+
+import com.velocitypowered.proxy.protocol.ProtocolUtils;
+import com.velocitypowered.proxy.protocol.SkippedCompressedPacket;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+@Sharable
+public class SkippedPacketWriter extends MessageToByteEncoder<SkippedCompressedPacket> {
+
+  public static final SkippedPacketWriter INSTANCE = new SkippedPacketWriter();
+
+  @Override
+  protected void encode(ChannelHandlerContext ctx, SkippedCompressedPacket packet, ByteBuf out)
+      throws Exception {
+    try {
+      ProtocolUtils.writeVarInt(out, packet.packetLength);
+      out.writeBytes(packet.buffer);
+    } finally {
+      packet.buffer.release();
+    }
+  }
+}


### PR DESCRIPTION
If compression of connection is enabled, we try to decompress first 5 bytes (max Varint length) in the input packet as its ID. Compressed packet will be written to client/server directly without unnecessary decompression if ID of the packet is not registered in packet registry. For example, large packets such as chunk data and entity metadata will be skipped in most cases. _Tested on Minecraft 1.16.2._

Debug logs:
![image](https://user-images.githubusercontent.com/21067004/90625414-34c03a80-e222-11ea-970d-54c39ff093f1.png)
