### PR TITLE
Fix kyori adventure title

### DIFF
--- a/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
+++ b/proxy/src/main/java/com/velocitypowered/proxy/connection/client/ConnectedPlayer.java
@@ -308,9 +308,12 @@ public class ConnectedPlayer implements MinecraftConnectionAssociation, Player {
     connection.delayedWrite(titlePkt);
 
     TitlePacket timesPkt = TitlePacket.timesForProtocolVersion(this.getProtocolVersion());
-    timesPkt.setFadeIn((int) DurationUtils.convertDurationToTicks(title.fadeInTime()));
-    timesPkt.setStay((int) DurationUtils.convertDurationToTicks(title.stayTime()));
-    timesPkt.setFadeOut((int) DurationUtils.convertDurationToTicks(title.fadeOutTime()));
+    net.kyori.adventure.title.Title.Times times = title.times();
+    if (times != null) {
+      timesPkt.setFadeIn((int) DurationUtils.convertDurationToTicks(times.fadeIn()));
+      timesPkt.setStay((int) DurationUtils.convertDurationToTicks(times.stay()));
+      timesPkt.setFadeOut((int) DurationUtils.convertDurationToTicks(times.fadeOut()));
+    }
     connection.delayedWrite(timesPkt);
 
     connection.flush();


### PR DESCRIPTION
As of commit https://github.com/KyoriPowered/adventure/commit/98dd0aa015e475aa2dac3668490a7bc85b992fc9, the methods `Title#fadeInTime()`, `Title#stayTime()` and `Title#fadeOutTime()` no longer exist.