### PR TITLE
Track some dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,12 @@ allprojects {
         // dependency versions
         textVersion = '3.0.4'
         adventureVersion = '4.0.0-SNAPSHOT'
-        junitVersion = '5.3.0-M1'
-        slf4jVersion = '1.7.25'
+        junitVersion = '5.7.0'
+        slf4jVersion = '1.7.30'
         log4jVersion = '2.13.3'
-        nettyVersion = '4.1.51.Final'
-        guavaVersion = '25.1-jre'
-        checkerFrameworkVersion = '2.7.0'
+        nettyVersion = '4.1.52.Final'
+        guavaVersion = '29.0-jre'
+        checkerFrameworkVersion = '3.6.1'
         configurateVersion = '3.7.1'
 
         getCurrentShortRevision = {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ allprojects {
         slf4jVersion = '1.7.30'
         log4jVersion = '2.13.3'
         nettyVersion = '4.1.52.Final'
-        guavaVersion = '29.0-jre'
+        guavaVersion = '25.1-jre'
         checkerFrameworkVersion = '3.6.1'
         configurateVersion = '3.7.1'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -56,16 +56,16 @@ dependencies {
 
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.4' // command-line options
     implementation 'net.minecrell:terminalconsoleappender:1.2.0'
-    runtimeOnly 'org.jline:jline-terminal-jansi:3.12.1' // Needed for JLine
+    runtimeOnly 'org.jline:jline-terminal-jansi:3.16.0' // Needed for JLine
     runtimeOnly 'com.lmax:disruptor:3.4.2' // Async loggers
 
-    implementation 'it.unimi.dsi:fastutil:8.2.3'
+    implementation 'it.unimi.dsi:fastutil:8.4.1'
     implementation 'net.kyori:event-method-asm:4.0.0-SNAPSHOT'
     implementation 'net.kyori:adventure-nbt:4.0.0-SNAPSHOT'
 
-    implementation 'org.asynchttpclient:async-http-client:2.10.4'
+    implementation 'org.asynchttpclient:async-http-client:2.12.1'
 
-    implementation 'com.spotify:completable-futures:0.3.2'
+    implementation 'com.spotify:completable-futures:0.3.3'
 
     implementation 'com.electronwill.night-config:toml:3.6.3'
 


### PR DESCRIPTION
junit: 5.3.0-M1 -> 5.7.0
slf4j: 1.7.25 -> 1.7.30
netty: 4.1.51.Final -> 4.1.52.Final
guava: 25.1-jre -> 29.0-jre
checkerFramework: 2.7.0 -> 3.6.1
jline-terminal-jansi: 3.12.1 -> 3.16.0
fastutil: 8.2.3 -> 8.4.1
async-http-client: 2.10.4 -> 2.12.1
completable-futures: 0.3.2 -> 0.3.3
gradle-wrapper: 6.6 -> 6.6.1

BREAKING CHANGE: No breaking change